### PR TITLE
Changed the url for the ds download to include the version in the path

### DIFF
--- a/sp/bootstrap.sh
+++ b/sp/bootstrap.sh
@@ -6,7 +6,7 @@ echo "Working on SP boostrap steps"
 mkdir -p _dl
 cd _dl
 echo "Downloading embedded-discovery-service ${EDS_F}"
-curl -JOLs http://shibboleth.net/downloads/embedded-discovery-service/latest/${EDS_F}
+curl -JOLs http://shibboleth.net/downloads/embedded-discovery-service/${EDS_V}/${EDS_F}
 cd ..
 mkdir -p _work
 cd _work


### PR DESCRIPTION
The url referenced in the path for the ds download was trying to fetch
from latest and when the version gets a bump, the bootstap script fails
to download the ds tarball. Including the version in the path fixes this
issue.